### PR TITLE
Add combined item probability view

### DIFF
--- a/src/app/inventory-management/_components/grid.tsx
+++ b/src/app/inventory-management/_components/grid.tsx
@@ -4,7 +4,7 @@ import { Tile } from "@/app/inventory-management/_components/tile";
 import type { InventoryManagementResult } from "@/workers/types";
 import { useEffect, useState } from "react";
 
-export type DisplayedItem = 1 | 2 | 3;
+export type DisplayedItem = 1 | 2 | 3 | "1+2" | "1+3" | "2+3";
 
 export type BlockedCoords = {
   x: number;
@@ -75,8 +75,16 @@ export function Grid({
           }
 
           if (displayedItem) {
-            newGrid[y][x].value =
-              probabilities[y][x].itemTypes[displayedItem - 1];
+            if (typeof displayedItem === "number") {
+              newGrid[y][x].value =
+                probabilities[y][x].itemTypes[displayedItem - 1];
+            } else {
+              const indexes = displayedItem.split("+").map((v) => Number(v) - 1);
+              newGrid[y][x].value = indexes.reduce(
+                (acc, idx) => acc + probabilities[y][x].itemTypes[idx],
+                0,
+              );
+            }
           } else {
             newGrid[y][x].value = probabilities[y][x].total;
           }

--- a/src/app/inventory-management/_components/simulator-view.tsx
+++ b/src/app/inventory-management/_components/simulator-view.tsx
@@ -295,6 +295,8 @@ export function InventoryManagementSimulatorView() {
   function changeDisplayedItem(value: string) {
     if (value === "all") {
       setDisplayedItem(undefined);
+    } else if (value.includes("+")) {
+      setDisplayedItem(value as DisplayedItem);
     } else {
       setDisplayedItem(Number(value) as DisplayedItem);
     }
@@ -615,6 +617,18 @@ export function InventoryManagementSimulatorView() {
 
           <ToggleGroupItem className="px-4" value="3">
             3
+          </ToggleGroupItem>
+
+          <ToggleGroupItem className="px-4" value="1+2">
+            1 + 2
+          </ToggleGroupItem>
+
+          <ToggleGroupItem className="px-4" value="1+3">
+            1 + 3
+          </ToggleGroupItem>
+
+          <ToggleGroupItem className="px-4" value="2+3">
+            2 + 3
           </ToggleGroupItem>
         </ToggleGroup>
       </div>


### PR DESCRIPTION
## Summary
- allow toggling probabilities for pairs of items in Inventory Management
- parse pair selection in simulator view

## Testing
- `pnpm lint` *(fails: ESLint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684823d30c2483209cd8b9f9eb12536e